### PR TITLE
Replace hero CTA with store buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,13 @@
       opacity: 0.85;
     }
 
+    .cta-buttons {
+      display: flex;
+      justify-content: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
     /* ---------- Footer ---------- */
     footer {
       background: var(--dark);
@@ -129,7 +136,10 @@
       <p>
         Gigditty helps musicians, managers, and bands streamline gigs, groups, and payouts—so you can focus on the music, not the paperwork.
       </p>
-      <a href="https://gigditty.app" class="cta-button" target="_blank" rel="noopener">Explore the App</a>
+      <div class="cta-buttons">
+        <a href="https://apps.apple.com/us/app/gigditty/id6743448372" class="cta-button" target="_blank" rel="noopener">Get on iOS</a>
+        <a href="#" class="cta-button" target="_blank" rel="noopener">Get on Android</a>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- add `.cta-buttons` layout to style multiple call to action buttons
- link to iOS store and add Android placeholder

## Testing
- `npm test` *(fails: could not find package.json)*